### PR TITLE
pretext to start a discussion ;)

### DIFF
--- a/jacklib/api.py
+++ b/jacklib/api.py
@@ -409,7 +409,7 @@ def get_version_string():
     return None
 
 
-def client_open(client_name, options, status, uuid=""):
+def client_open(client_name, options, status, uuid="") -> 'pointer[jack_client_t]':
     if jlib.jack_client_open:
         return jlib.jack_client_open(_e(client_name), options, status, _e(uuid) if uuid else None)
 

--- a/jacklib/api.py
+++ b/jacklib/api.py
@@ -346,13 +346,8 @@ class jack_description_t(Structure):
 # Callbacks
 
 JackThreadCallback = CFUNCTYPE(c_void_p, c_void_p)
-JackSyncCallback = CFUNCTYPE(c_int, jack_transport_state_t, POINTER(jack_position_t), c_void_p)
 JackTimebaseCallback = CFUNCTYPE(
     None, jack_transport_state_t, jack_nframes_t, POINTER(jack_position_t), c_int, c_void_p
-)
-JackSessionCallback = CFUNCTYPE(None, POINTER(jack_session_event_t), c_void_p)
-JackPropertyChangeCallback = CFUNCTYPE(
-    None, jack_uuid_t, c_char_p, jack_property_change_t, c_void_p
 )
 JackErrorCallback = CFUNCTYPE(None, c_char_p)
 
@@ -627,11 +622,11 @@ _CBS = (
     _Cb('set_property_change',
         CFUNCTYPE(None, jack_uuid_t, c_char_p, jack_property_change_t, c_void_p),
         c_int),
-    # following is not really a callback setter, but it uses the same scheme
-    _Cb('set_process_thread',
-        CFUNCTYPE(c_void_p, c_void_p),
-        c_int,
-        suffix=''),
+    ## following is not really a callback setter, but it uses the same scheme
+    # _Cb('set_process_thread',
+    #     CFUNCTYPE(c_void_p, c_void_p),
+    #     c_int,
+    #     suffix='')
     )
 
 

--- a/jacklib/helpers.py
+++ b/jacklib/helpers.py
@@ -15,6 +15,7 @@
 #
 # For a full copy of the GNU General Public License see the file COPYING.md.
 
+from ctypes import pointer, c_char_p
 from . import api as jacklib
 
 
@@ -59,27 +60,29 @@ def get_jack_status_error_string(cStatus):
     return ";\n".join(errorString) + "."
 
 
-def c_char_p_p_to_list(c_char_p_p, encoding=jacklib.ENCODING, errors="ignore"):
+def c_char_p_p_to_list(c_char_p_p: 'pointer[c_char_p]',
+                       encoding=jacklib.ENCODING,
+                       errors="ignore") -> list[str]:
     """Convert C char** -> Python list of strings."""
     i = 0
-    retList = []
+    ret_list = list[str]()
 
     if not c_char_p_p:
-        return retList
+        return ret_list
 
     while True:
         new_char_p = c_char_p_p[i]
         if not new_char_p:
             break
 
-        retList.append(new_char_p.decode(encoding=encoding, errors=errors))
+        ret_list.append(new_char_p.decode(encoding=encoding, errors=errors))
         i += 1
 
     jacklib.free(c_char_p_p)
-    return retList
+    return ret_list
 
 
-def voidptr2str(void_p):
+def voidptr2str(void_p) -> str:
     """Convert C void* -> string."""
     char_p = jacklib.cast(void_p, jacklib.c_char_p)
     string = str(char_p.value, encoding="utf-8")


### PR DESCRIPTION
As the title say, I don't expect this PR to be merged as it is. I made some changes in many parts for many reasons, I could  propose things one by one of course.
I am motivated to make some work on this lib, I use it myself 3 times in my softs (Patchance + RaySession x 2).

I would be happy to have your opinion about the following points:

1. typing everywhere, I find it really nicer to know the types in the IDE. It includes typing on Structure classes. It allows easier auto-completion.  
2. I made something on callbacks declarations because I saw a big redundancy of code with many try/except structs, this way it works the same, API functions for setting callbacks are now decorated, and all is made in the decorator.
I was wondering why there were callbacks CFUNCTYPE saved as global (_thread_init_callback, _shutdown_callback ... example line 699/700) in the API functions. I discovered that it was just a way to prevent python cleaner to remove these objects. In addition to the fact that I find it quite dirty, I see the impossibility to get 2 jack clients with same callback working correctly (the 2nd callback will erase the 1st, not tested but I am pretty sure). That's why I simply add theses objects to a list (_used_callbacks).
3. I find the file too big, hard to parse. It would be nice to split it, having the API functions in the same file.
4. I find strange to have a c_char_p pointer as output from get_all_ports, I think it should deliver a list[str] directly.
5. enums could use enum lib (with IntEnum or IntFlag), I have been using it for some time, I find it nice for many reasons (debug, easier import, parsing all values, readability...). 